### PR TITLE
Add the ability to configure the Single Columns within the JSON configuration

### DIFF
--- a/HowToUse.md
+++ b/HowToUse.md
@@ -58,8 +58,13 @@ The project can be found on [nuget](https://www.nuget.org/packages/HaemmerElectr
             "TimeStamp": "Timestamp",
             "LogEvent": "Properties"
           },
-          "loggerPropertyColumnOptions": {
-            "TestColumnName": "TestProperty"
+         "loggerPropertyColumnOptions": {
+            "TestColumnName": {
+    		  "Name": "TestProperty",
+              "Format": "{0}",
+              "WriteMethod": "Raw",
+              "DbType": "Text"
+            }
           },
           "simpleColumnOptions": {},
           "period": "0.00:00:30",

--- a/src/SerilogSinksPostgreSQL.IntegrationTests/BaseTests.cs
+++ b/src/SerilogSinksPostgreSQL.IntegrationTests/BaseTests.cs
@@ -1,0 +1,14 @@
+﻿namespace SerilogSinksPostgreSQL.IntegrationTests
+{
+    /// <summary>
+    /// Common properties for Tests
+    /// </summary>
+    public abstract class BaseTests
+    {
+        /// <summary>
+        ///     The connection string.
+        /// </summary>
+        protected const string ConnectionString =
+            "User ID=postgres;Password=postgres;Host=localhost;Port=5432;Database=Serilog";
+    }
+}

--- a/src/SerilogSinksPostgreSQL.IntegrationTests/DbWriteTests.cs
+++ b/src/SerilogSinksPostgreSQL.IntegrationTests/DbWriteTests.cs
@@ -25,14 +25,8 @@ namespace SerilogSinksPostgreSQL.IntegrationTests
     /// <summary>
     ///     This class is used to test the writing to the database.
     /// </summary>
-    public class DbWriteTests
+    public class DbWriteTests : BaseTests
     {
-        /// <summary>
-        ///     The connection string.
-        /// </summary>
-        private const string ConnectionString =
-            "User ID=postgres;Password=postgres;Host=localhost;Port=5432;Database=Serilog";
-
         /// <summary>
         ///     The table name.
         /// </summary>

--- a/src/SerilogSinksPostgreSQL.IntegrationTests/DbWriteWithSchemaTests.cs
+++ b/src/SerilogSinksPostgreSQL.IntegrationTests/DbWriteWithSchemaTests.cs
@@ -25,14 +25,8 @@ namespace SerilogSinksPostgreSQL.IntegrationTests
     /// <summary>
     ///     This class is used to test the writing of data to the database with schemas.
     /// </summary>
-    public class DbWriteWithSchemaTests
+    public class DbWriteWithSchemaTests : BaseTests
     {
-        /// <summary>
-        ///     The connection string.
-        /// </summary>
-        private const string ConnectionString =
-            "User ID=postgres;Password=postgres;Host=localhost;Port=5432;Database=Serilog";
-
         /// <summary>
         ///     The schema name. This needs to be present in the database, e.g. create it manually.
         /// </summary>

--- a/src/SerilogSinksPostgreSQL.IntegrationTests/JsonConfigTest.cs
+++ b/src/SerilogSinksPostgreSQL.IntegrationTests/JsonConfigTest.cs
@@ -23,13 +23,8 @@ namespace SerilogSinksPostgreSQL.IntegrationTests
     /// Tests for creating PostgreSql logger from JSON config.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "Reviewed. Suppression is OK here.")]
-    public class JsonConfigTest
+    public class JsonConfigTest : BaseTests
     {
-        /// <summary>
-        /// The connection string.
-        /// </summary>
-        private const string ConnectionString = "User ID=postgres;Password=postgres;Host=localhost;Port=5432;Database=Serilog;";
-
         /// <summary>
         /// The test logs.
         /// </summary>

--- a/src/SerilogSinksPostgreSQL.IntegrationTests/PostgreSinkConfiguration.json
+++ b/src/SerilogSinksPostgreSQL.IntegrationTests/PostgreSinkConfiguration.json
@@ -16,9 +16,13 @@
             "LogEvent": "Properties"
           },
           "loggerPropertyColumnOptions": {
-            "TestColumnName": "TestProperty"
+            "TestColumnName": {
+              "Format": "{0}",
+              "Name": "TestProperty",
+              "WriteMethod": "Raw",
+              "DbType": "Text"
+            }
           },
-          "simpleColumnOptions": {},
           "period": "0.00:00:30",
           "batchSizeLimit": 50
         }

--- a/src/SerilogSinksPostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
+++ b/src/SerilogSinksPostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
@@ -113,7 +113,7 @@ namespace Serilog
             string connectionString,
             string tableName,
             IDictionary<string, string> loggerColumnOptions = null,
-            IDictionary<string, string> loggerPropertyColumnOptions = null,
+            IDictionary<string, SinglePropertyColumnWriter> loggerPropertyColumnOptions = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
@@ -184,9 +184,10 @@ namespace Serilog
 
             columns = columns ?? new Dictionary<string, ColumnWriterBase>();
 
+
             foreach (var columnOption in loggerPropertyColumnOptions)
             {
-                columns.Add(columnOption.Key, new SinglePropertyColumnWriter(columnOption.Value));
+                columns.Add(columnOption.Key, columnOption.Value);
             }
 
             return sinkConfiguration.PostgreSql(

--- a/src/SerilogSinksPostgreSQL/Sinks/PostgreSQL/SinglePropertyColumnWriter.cs
+++ b/src/SerilogSinksPostgreSQL/Sinks/PostgreSQL/SinglePropertyColumnWriter.cs
@@ -26,6 +26,12 @@ namespace Serilog.Sinks.PostgreSQL
     /// <seealso cref="ColumnWriterBase" />
     public class SinglePropertyColumnWriter : ColumnWriterBase
     {
+        /// <summary></summary>
+        public SinglePropertyColumnWriter() : base(NpgsqlDbType.Text)
+        {
+
+        }
+
         /// <inheritdoc cref="ColumnWriterBase" />
         /// <summary>
         ///     Initializes a new instance of the <see cref="SinglePropertyColumnWriter" /> class.
@@ -55,19 +61,19 @@ namespace Serilog.Sinks.PostgreSQL
         ///     Gets the format.
         /// </summary>
         // ReSharper disable once MemberCanBePrivate.Global
-        public string Format { get; }
+        public string Format { get; set; }
 
         /// <summary>
         ///     Gets the name.
         /// </summary>
         // ReSharper disable once MemberCanBePrivate.Global
-        public string Name { get; }
+        public string Name { get; set; }
 
         /// <summary>
         ///     Gets the write method.
         /// </summary>
         // ReSharper disable once MemberCanBePrivate.Global
-        public PropertyWriteMethod WriteMethod { get; }
+        public PropertyWriteMethod WriteMethod { get; set; }
 
         /// <inheritdoc cref="ColumnWriterBase" />
         /// <summary>


### PR DESCRIPTION
The constructor parameters for SinglePropertyColumnWriter can be configured in the JSON file