### PR TITLE
Changed to attach correct column writer to exception column

### DIFF
--- a/src/SerilogSinksPostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
+++ b/src/SerilogSinksPostgreSQL/LoggerConfigurationPostgreSQLExtensions.cs
@@ -157,7 +157,7 @@ namespace Serilog
                             columns.Add(columnOption.Key, new RenderedMessageColumnWriter());
                             break;
                         case "Exception":
-                            columns.Add(columnOption.Key, new RenderedMessageColumnWriter());
+                            columns.Add(columnOption.Key, new ExceptionColumnWriter());
                             break;
                         case "IdAutoIncrement":
                             columns.Add(columnOption.Key, new IdAutoIncrementColumnWriter());


### PR DESCRIPTION
This small change should fix the problem where the exception column in the database table gets the wrong data written to it